### PR TITLE
change username from uuid to str type

### DIFF
--- a/lizaalert-backend/authentication/adapters.py
+++ b/lizaalert-backend/authentication/adapters.py
@@ -41,7 +41,7 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         Изменен способ предзаполнения поля username нового пользователя
         на случайно сгенерированный UUID.
         """
-        username = uuid.uuid4()
+        username = str(uuid.uuid4())
         first_name = data.get("first_name")
         last_name = data.get("last_name")
         email = data.get("email")

--- a/lizaalert-backend/settings/settings.py
+++ b/lizaalert-backend/settings/settings.py
@@ -17,6 +17,7 @@ ALLOWED_HOSTS = env.list(
     "ALLOWED_HOSTS",
     [
         "0.0.0.0",
+        "127.0.0.1",
     ],
 )
 CSRF_TRUSTED_ORIGINS = ["http://localhost:8000", "http://0.0.0.0:8000"]


### PR DESCRIPTION
Хотфикс к [предыдущему PR](https://github.com/Studio-Yandex-Practicum/lizaalert_backend/pull/30). В username попадал тип  uuid4, а не str.