### PR TITLE
Bugfix/swagger schema subscription

### DIFF
--- a/src/lizaalert/courses/views.py
+++ b/src/lizaalert/courses/views.py
@@ -72,7 +72,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
         return course
 
     def get_serializer_class(self):
-        if self.action == 'enroll' or self.action == 'unroll':
+        if self.action == "enroll" or self.action == "unroll":
             return None
         if self.action == "retrieve":
             return CourseDetailSerializer


### PR DESCRIPTION
Сваггер и редок возвращали некорректную схему, для подписки и отписки. Сериализация для них не требуется, поэтому убрал ее, чтобы не путать сваггер.