### PR TITLE
TM-41 [bugfix] Данные, введённые в профиль в swagger, не сохраняются на бэке

### DIFF
--- a/src/lizaalert/users/serializers.py
+++ b/src/lizaalert/users/serializers.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from rest_framework import serializers
 
-from lizaalert.users.models import Badge, Level, Location, UserRole, Volunteer
+from lizaalert.users.models import Badge, Department, Level, Location, UserRole, Volunteer
 
 User = get_user_model()
 
@@ -52,6 +52,10 @@ class VolunteerSerializer(serializers.ModelSerializer):
             location = validated_data.get("location", None)
             if location and (Location.objects.filter(region=location["region"]).exists()):
                 instance.location = Location.objects.get(region=location["region"])
+
+            department = validated_data.get("department", None)
+            if department and (Department.objects.filter(title=department["title"]).exists()):
+                instance.department = Department.objects.get(title=department["title"])
 
             full_name = validated_data.get("user", {}).get("full_name", None)
             if full_name is not None:

--- a/src/lizaalert/users/views.py
+++ b/src/lizaalert/users/views.py
@@ -58,8 +58,9 @@ class VolunteerAPIview(APIView):
     @swagger_auto_schema(
         operation_description="""
         Внесение изменений в профиль пользователя
-        
-        Для внесения изменений в поля department и location необходимо предварительно создать соответсвующие экземпляры моделей Department и Location. 
+
+        Для внесения изменений в поля department и location необходимо
+        предварительно создать соответсвующие экземпляры моделей Department и Location. 
         """,
         request_body=VolunteerSerializer,
         responses={200: VolunteerSerializer(), 400: Error400Serializer(), 404: Error404Serializer()},

--- a/src/lizaalert/users/views.py
+++ b/src/lizaalert/users/views.py
@@ -56,7 +56,11 @@ class VolunteerAPIview(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @swagger_auto_schema(
-        operation_description="Внесение изменений в профиль пользователя",
+        operation_description="""
+        Внесение изменений в профиль пользователя
+        
+        Для внесения изменений в поля department и location необходимо предварительно создать соответсвующие экземпляры моделей Department и Location. 
+        """,
         request_body=VolunteerSerializer,
         responses={200: VolunteerSerializer(), 400: Error400Serializer(), 404: Error404Serializer()},
     )

--- a/src/lizaalert/users/views.py
+++ b/src/lizaalert/users/views.py
@@ -60,7 +60,7 @@ class VolunteerAPIview(APIView):
         Внесение изменений в профиль пользователя
 
         Для внесения изменений в поля department и location необходимо
-        предварительно создать соответсвующие экземпляры моделей Department и Location. 
+        предварительно создать соответсвующие экземпляры моделей Department и Location.
         """,
         request_body=VolunteerSerializer,
         responses={200: VolunteerSerializer(), 400: Error400Serializer(), 404: Error404Serializer()},


### PR DESCRIPTION
Исправлен сериализатор для patch-запроса на ручку profile. Теперь можно вносить изменения в поле department (направление).
Добавлено описание в swagger, относительно необходимости предварительного создания экземпляров классов location и department.