### PR TITLE
MIL-110 Не отображать удаленные объекты

### DIFF
--- a/src/lizaalert/courses/admin.py
+++ b/src/lizaalert/courses/admin.py
@@ -17,6 +17,7 @@ from lizaalert.courses.models import (
     LessonProgressStatus,
     Subscription,
 )
+from lizaalert.settings.admin_setup import BaseAdmin
 
 
 class CourseFaqInline(admin.TabularInline):
@@ -66,7 +67,7 @@ class ChapterInline(admin.TabularInline):
 
 
 @admin.register(Cohort)
-class CohortAdmin(admin.ModelAdmin):
+class CohortAdmin(BaseAdmin):
     """
     Админка когорты.
 
@@ -96,7 +97,7 @@ class CohortAdmin(admin.ModelAdmin):
 
 
 @admin.register(Course)
-class CourseAdmin(admin.ModelAdmin):
+class CourseAdmin(BaseAdmin):
     """Админка курса."""
 
     inlines = (CourseFaqInline, CourseKnowledgeInline, ChapterInline)
@@ -127,7 +128,7 @@ class CourseAdmin(admin.ModelAdmin):
 
 
 @admin.register(Chapter)
-class ChapterAdmin(admin.ModelAdmin):
+class ChapterAdmin(BaseAdmin):
     """Админка главы."""
 
     inlines = (LessonInline,)
@@ -147,7 +148,7 @@ class ChapterAdmin(admin.ModelAdmin):
 
 
 @admin.register(LessonProgressStatus)
-class LessonProgressStatusAdmin(admin.ModelAdmin):
+class LessonProgressStatusAdmin(BaseAdmin):
     ordering = ("-updated_at",)
     list_display = (
         "subscribed_user",
@@ -172,7 +173,7 @@ class LessonProgressStatusAdmin(admin.ModelAdmin):
 
 
 @admin.register(ChapterProgressStatus)
-class ChapterProgressStatusAdmin(admin.ModelAdmin):
+class ChapterProgressStatusAdmin(BaseAdmin):
 
     raw_id_fields = ("subscription",)
     ordering = ("-updated_at",)
@@ -199,7 +200,7 @@ class ChapterProgressStatusAdmin(admin.ModelAdmin):
 
 
 @admin.register(CourseProgressStatus)
-class CourseProgressStatusAdmin(admin.ModelAdmin):
+class CourseProgressStatusAdmin(BaseAdmin):
 
     raw_id_fields = ("subscription",)
     ordering = ("-updated_at",)
@@ -225,7 +226,7 @@ class CourseProgressStatusAdmin(admin.ModelAdmin):
 
 
 @admin.register(FAQ)
-class FaqAdmin(admin.ModelAdmin):
+class FaqAdmin(BaseAdmin):
     """Админка для FAQ."""
 
     inlines = (CourseFaqInline,)
@@ -239,7 +240,7 @@ class FaqAdmin(admin.ModelAdmin):
 
 
 @admin.register(Knowledge)
-class KnowledgeAdmin(admin.ModelAdmin):
+class KnowledgeAdmin(BaseAdmin):
     """Aдминка для Knowledge."""
 
     inlines = (CourseKnowledgeInline,)
@@ -253,7 +254,7 @@ class KnowledgeAdmin(admin.ModelAdmin):
 
 
 @admin.register(Lesson)
-class LessonAdmin(admin.ModelAdmin):
+class LessonAdmin(BaseAdmin):
     """Админка для урока."""
 
     raw_id_fields = (
@@ -274,7 +275,7 @@ class LessonAdmin(admin.ModelAdmin):
 
 
 @admin.register(Subscription)
-class SubscriptionAdmin(admin.ModelAdmin):
+class SubscriptionAdmin(BaseAdmin):
     """Админка подписки."""
 
     raw_id_fields = ("user", "course")

--- a/src/lizaalert/courses/mixins.py
+++ b/src/lizaalert/courses/mixins.py
@@ -20,6 +20,7 @@ class TimeStampedModel(models.Model):
     all_objects - менеджер модели без поддержки мягкого удаления
 
     переопределен метод delete для мягкого удаления записи.
+    переопределены методы str и repr для отображения статуса удаления записи.
     """
 
     created_at = models.DateTimeField(auto_now_add=True)
@@ -34,6 +35,18 @@ class TimeStampedModel(models.Model):
     def delete(self, *args, **kwargs):
         self.deleted_at = timezone.now()
         self.save()
+
+    def __str__(self):
+        base_str = super().__str__()
+        if self.deleted_at:
+            return f"{base_str} (deleted)"
+        return base_str
+
+    def __repr__(self):
+        base_repr = super().__repr__()
+        if self.deleted_at:
+            return f"{base_repr} (deleted)"
+        return base_repr
 
 
 def order_number_mixin(step, parent_field):

--- a/src/lizaalert/courses/mixins.py
+++ b/src/lizaalert/courses/mixins.py
@@ -2,6 +2,9 @@ from django.apps import apps
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.db.models import Max
+from django.utils import timezone
+
+from lizaalert.settings.managers import SoftDeleteManager
 
 
 class TimeStampedModel(models.Model):
@@ -11,15 +14,26 @@ class TimeStampedModel(models.Model):
     created_at* - дата создания записи об уроке, автоматическое проставление
     текущего времени
     updated_at* - дата обновления записи об уроке, автоматическое проставление
-    текущего времени.
+    текущего времени
+    deleted_at - дата удаления записи об уроке, автоматическое проставление
+    objects - менеджер модели с поддержкой мягкого удаления
+    all_objects - менеджер модели без поддержки мягкого удаления
+
+    переопределен метод delete для мягкого удаления записи.
     """
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True, db_index=True)
     deleted_at = models.DateTimeField(null=True, blank=True)
+    objects = SoftDeleteManager()
+    all_objects = models.Manager()
 
     class Meta:
         abstract = True
+
+    def delete(self, *args, **kwargs):
+        self.deleted_at = timezone.now()
+        self.save()
 
 
 def order_number_mixin(step, parent_field):

--- a/src/lizaalert/courses/mixins.py
+++ b/src/lizaalert/courses/mixins.py
@@ -20,7 +20,7 @@ class TimeStampedModel(models.Model):
     all_objects - менеджер модели без поддержки мягкого удаления
 
     переопределен метод delete для мягкого удаления записи.
-    переопределены методы str и repr для отображения статуса удаления записи.
+    переопределен метод repr для отображения статуса удаления записи.
     """
 
     created_at = models.DateTimeField(auto_now_add=True)
@@ -35,12 +35,6 @@ class TimeStampedModel(models.Model):
     def delete(self, *args, **kwargs):
         self.deleted_at = timezone.now()
         self.save()
-
-    def __str__(self):
-        base_str = super().__str__()
-        if self.deleted_at:
-            return f"{base_str} (deleted)"
-        return base_str
 
     def __repr__(self):
         base_repr = super().__repr__()

--- a/src/lizaalert/homeworks/admin.py
+++ b/src/lizaalert/homeworks/admin.py
@@ -4,6 +4,7 @@ from tinymce.widgets import TinyMCE
 
 from lizaalert.courses.models import Lesson
 from lizaalert.homeworks.models import Homework
+from lizaalert.settings.admin_setup import BaseAdmin
 
 
 class HomeworkAdminForm(forms.ModelForm):
@@ -16,7 +17,7 @@ class HomeworkAdminForm(forms.ModelForm):
 
 
 @admin.register(Homework)
-class HomeworkAdmin(admin.ModelAdmin):
+class HomeworkAdmin(BaseAdmin):
     """Админка домашних заданий."""
 
     form = HomeworkAdminForm

--- a/src/lizaalert/quizzes/admin.py
+++ b/src/lizaalert/quizzes/admin.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError as PydanticValidationError
 
 from lizaalert.quizzes.models import Question, Quiz, UserAnswer
 from lizaalert.quizzes.validators import ValidateAnswersModel
+from lizaalert.settings.admin_setup import BaseAdmin
 
 
 class QuestionAdminForm(forms.ModelForm):
@@ -24,13 +25,13 @@ class QuestionAdminForm(forms.ModelForm):
 
 
 @admin.register(Quiz)
-class QuizAdmin(admin.ModelAdmin):
+class QuizAdmin(BaseAdmin):
     list_display = ("id", "title", "created_at", "deleted_at")
     search_fields = ("title",)
 
 
 @admin.register(Question)
-class QuestionAdmin(admin.ModelAdmin):
+class QuestionAdmin(BaseAdmin):
     form = QuestionAdminForm
     list_display = ("id", "title", "quiz", "question_type", "order_number", "created_at", "deleted_at")
     list_filter = ("quiz",)
@@ -38,7 +39,7 @@ class QuestionAdmin(admin.ModelAdmin):
 
 
 @admin.register(UserAnswer)
-class UserAnswerAdmin(admin.ModelAdmin):
+class UserAnswerAdmin(BaseAdmin):
     list_display = ("id", "user", "quiz")
     readonly_fields = ("user", "quiz")
     search_fields = ("user__username", "quiz__title")

--- a/src/lizaalert/settings/admin_setup.py
+++ b/src/lizaalert/settings/admin_setup.py
@@ -1,0 +1,83 @@
+from django.contrib import admin, messages
+from django.contrib.admin.actions import delete_selected as delete_selected_original
+from django.utils.translation import ngettext
+
+
+class ShowDeletedObjectsFilter(admin.SimpleListFilter):
+
+    title = "Показать удаленные записи"
+    parameter_name = "is_deleted"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("1", ("Показать удаленные")),
+            ("0", ("Скрыть удаленные")),
+        )
+
+    def queryset(self, request, queryset):
+        match self.value():
+            case "1":
+                return queryset.filter(deleted_at__isnull=False)
+            case "0":
+                return queryset.filter(deleted_at__isnull=True)
+        return queryset
+
+
+class BaseAdmin(admin.ModelAdmin):
+    """
+    База для панели админа.
+
+    По дефолту добавляет фильтр удаленных объектов, флаг удаленности и запрещает редактировать
+     дату удаления.
+    Добавляет действия восстановления и мягкого удаления выбранных объектов.
+    Использует менеджер модели с отображением всех объектов в базе данных.
+    Стандарнтый текст для удаления объектов заменен на новый, сообщающий о безвозвратном удалении.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.list_display += ("is_deleted",)
+        self.readonly_fields += ("deleted_at",)
+        self.actions = ("soft_restore", "soft_delete_selected", "delete_selected_custom")
+        self.list_filter += (ShowDeletedObjectsFilter,)
+
+    def get_queryset(self, request):
+        """Возвращает queryset, исключая удаленные записи."""
+        return self.model.all_objects.all()
+
+    @admin.action(description="Удалить выбранные объекты")
+    def soft_delete_selected(self, request, queryset):
+        qs = self.model.objects.filter(pk__in=queryset.values_list("pk", flat=True))
+        qs.delete()
+
+    @admin.display(description="Доступен")
+    def is_deleted(self, obj):
+        """Флаг удаленности."""
+        return bool(not obj.deleted_at)
+
+    is_deleted.boolean = True
+
+    @admin.action(description="Восстановить выбранные объекты")
+    def soft_restore(self, request, queryset):
+        """Восстановление удаленных объектов."""
+        updated = queryset.update(deleted_at=None)
+        self.message_user(
+            request,
+            ngettext(
+                "%d запись была успешно восстановлена.",
+                "%d записей было успешко восстановлено.",
+                updated,
+            )
+            % updated,
+            messages.SUCCESS,
+        )
+
+    @admin.action(description="Безвозвратно удалить выбранные объекты")
+    def delete_selected_custom(self, request, queryset):
+        return delete_selected_original(self, request, queryset)
+
+    def get_actions(self, request):
+        actions = super().get_actions(request)
+        if "delete_selected" in actions:
+            del actions["delete_selected"]
+        return actions

--- a/src/lizaalert/settings/admin_setup.py
+++ b/src/lizaalert/settings/admin_setup.py
@@ -4,6 +4,11 @@ from django.utils.translation import ngettext
 
 
 class ShowDeletedObjectsFilter(admin.SimpleListFilter):
+    """
+    Фильтр для django admin.
+
+    Позволяет показывать/скрывать удаленные записи в админке.
+    """
 
     title = "Показать удаленные записи"
     parameter_name = "is_deleted"

--- a/src/lizaalert/settings/managers.py
+++ b/src/lizaalert/settings/managers.py
@@ -1,0 +1,17 @@
+from django.db import models
+from django.utils import timezone
+
+
+class SoftQuerySet(models.QuerySet):
+    """Queryset с мягким удалением и восстановлением."""
+
+    def delete(self):
+        self.update(deleted_at=timezone.now())
+
+
+class SoftDeleteManager(models.Manager):
+    """Менеджер модели с поддержкой мягкого удаления."""
+
+    def get_queryset(self):
+        """Возвращает queryset, исключая удаленные записи."""
+        return SoftQuerySet(self.model, using=self._db).filter(deleted_at__isnull=True)

--- a/src/lizaalert/webinars/admin.py
+++ b/src/lizaalert/webinars/admin.py
@@ -1,11 +1,12 @@
 from django.contrib import admin
 
 from lizaalert.courses.models import Lesson
+from lizaalert.settings.admin_setup import BaseAdmin
 from lizaalert.webinars.models import Webinar
 
 
 @admin.register(Webinar)
-class Webinar(admin.ModelAdmin):
+class Webinar(BaseAdmin):
     """
     Админка домашних заданий.
 

--- a/src/tests/test_courses.py
+++ b/src/tests/test_courses.py
@@ -856,3 +856,19 @@ class TestCourse:
 
         # 2. Проверяем, что урок с пройденным контентом можно завершить.
         assert_finish(lesson, ProgressionStatus.APPROVED)
+
+    def test_soft_delete(self):
+        """
+        Проверка мягкого удаления.
+
+        Создаем курс, удаляем его и проверяем, что он не отображается в списке курсов при
+         использовании менеджера objects и отображается при использовании менеджера all_objects.
+        """
+        course = CourseFactory()
+        Course.objects.filter(id=course.id).delete()
+        assert not Course.objects.filter(id=course.id).exists()
+        assert Course.all_objects.filter(id=course.id).exists()
+
+        # Проверяем появления маркировки (deleted) у удаленных объектов в методе __repr__
+        deleted_course = Course.all_objects.get(id=course.id)
+        assert deleted_course.__repr__() == course.__repr__() + " (deleted)"


### PR DESCRIPTION
Сейчас есть поле, в котором находится дата удаления, но эти объекты по прежнему отображаются

Предлагается:

добавить новый менеджер объектов:
- all_objects - возвращается список всех объектов
- objects - возвращает список не удаленных объектов

в админке добавить раскраску для списков элементов
- удаленные объекты отображаются с иконкой ❌

в __str__ указывать признак удаления объектов  <Lesson $id: $title (deleted)>

при удалении объектов в админке (через действие удалить) должны помечаться удаленными (устанавливаться дата удаления)